### PR TITLE
Ignore node_modules by default

### DIFF
--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -80,6 +80,7 @@ config, see the "copywrite init" command.`,
 		// Append default ignored search patterns (e.g., GitHub Actions workflows)
 		autoSkippedPatterns := []string{
 			".github/workflows/**",
+			"node_modules/**",
 		}
 		ignoredPatterns := lo.Union(conf.Project.HeaderIgnore, autoSkippedPatterns)
 

--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -80,7 +80,7 @@ config, see the "copywrite init" command.`,
 		// Append default ignored search patterns (e.g., GitHub Actions workflows)
 		autoSkippedPatterns := []string{
 			".github/workflows/**",
-			"node_modules/**",
+			"**node_modules/**",
 		}
 		ignoredPatterns := lo.Union(conf.Project.HeaderIgnore, autoSkippedPatterns)
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
The `node_modules` folder only stores third-party dependencies for builds. It will never need to receive copyright headers, so we are safe to ignore it.


### :link: External Links

<!-- JIRA Issues, RFC, etc. -->


### :+1: Definition of Done

- [x] New functionality works?
- [x] Manually tested

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
