### PR TITLE
Suppress "skipping file" logs as debug by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ freely in later steps.
 
 :bulb: Running the copywrite command with the `--plan` flag will return a non-zero exit code if the repo is out of compliance.
 
+## Debugging
+
+Copywrite supports several built-in features to aid with debugging. The first
+and most commonly used one is configurable log levels. Copywrite checks the
+`COPYWRITE_LOG_LEVEL` environment variable to determine which verbosity to use.
+The following log levels are supported:
+
+- `trace`
+- `debug`
+- `info`
+- `warn`
+- `error`
+- `off` (disables logging)
+
+Copywrite also checks for if the `RUNNER_DEBUG=1` environment variable is set,
+which will cause it to default to debug-level logging. This environment variable
+is set by Github Actions when in debug mode, and can be a useful default.
+The `COPYWRITE_LOG_LEVEL` setting takes precedence, however.
+
+It is often useful to introspect information about the state Copywrite finds
+itself in. The `copywrite debug` command can print the running configuration,
+whether or not a config file was loaded, what GitHub auth type is in use, and
+more. No sensitive information is printed, however.  
+
 ## Development
 
 ### IDE Settings

--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -96,6 +96,8 @@ config, see the "copywrite init" command.`,
 
 		// Wrap hclogger to use standard lib's log.Logger
 		stdcliLogger := cliLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			// InferLevels must be true so that addLicense can set the log level via
+			// log prefix, e.g. logger.Println("[DEBUG] this is inferred as a debug log")
 			InferLevels: true,
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
-	github.com/hashicorp/addLicense v1.4.0
+	github.com/hashicorp/addLicense v1.4.1
 	github.com/hashicorp/go-hclog v1.4.0
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
-github.com/hashicorp/addLicense v1.4.0 h1:7DWR96L4XRz3FKTSoCuUhU2CRckgEx0rPZueUvCGTRw=
-github.com/hashicorp/addLicense v1.4.0/go.mod h1:hdu2nu1sVqsSF9frnG6IqVgRwKztfuMvt4PAGsTSfyA=
+github.com/hashicorp/addLicense v1.4.1 h1:Ih1o91RdrqR65UMBwM75ZOH7qhnzcDkKbGbq9TQY6XM=
+github.com/hashicorp/addLicense v1.4.1/go.mod h1:hdu2nu1sVqsSF9frnG6IqVgRwKztfuMvt4PAGsTSfyA=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Fixes #19

hclog supports inferring log levels from a StandardLogger interface. In order to hide the sometimes annoying "Skipping File" lines from stdout, v1.4.1 of hashicorp/addLicense now prepends `[DEBUG]` to these log statements.

The default now looks like this:
```
❯ copywrite headers --plan
Executing in dry-run mode. Rerun without the `--plan` flag to apply changes.

Using license identifier: MPL-2.0

Exempting the following search patterns:
**/testdata/**

The following files are missing headers:
2023-02-01T17:46:07.842-0800 [INFO]  cli: cmd/report_repos.go
2023-02-01T17:46:07.842-0800 [INFO]  cli: cmd/debug.go
2023-02-01T17:46:07.842-0800 [INFO]  cli: cmd/dispatch.go
2023-02-01T17:46:07.842-0800 [INFO]  cli: cmd/license.go
2023-02-01T17:46:07.843-0800 [INFO]  cli: main.go
2023-02-01T17:46:07.843-0800 [INFO]  cli: repodata/repodata.go
2023-02-01T17:46:07.843-0800 [INFO]  cli: teststuff/test.go
Error: missing license header
exit status 1
```

The full logs can be retrieved by running with `COPYWRITE_LOG_LEVEL=debug` or `RUNNER_DEBUG=1`, which returns the original results:
```
❯ COPYWRITE_LOG_LEVEL=debug copywrite headers --plan
Executing in dry-run mode. Rerun without the `--plan` flag to apply changes.

Using license identifier: MPL-2.0

Exempting the following search patterns:
**/testdata/**

The following files are missing headers:
2023-02-01T17:46:22.566-0800 [DEBUG] cli: skipping: .github/workflows/.DS_Store
2023-02-01T17:46:22.566-0800 [DEBUG] cli: skipping: .github/workflows/build-and-release.yml
2023-02-01T17:46:22.566-0800 [DEBUG] cli: skipping: .github/workflows/golangci.yml
2023-02-01T17:46:22.567-0800 [DEBUG] cli: skipping: config/testdata/.DS_Store
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/config_with_schema_version.hcl
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/dispatch/full_dispatch.hcl
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/empty_config.hcl
2023-02-01T17:46:22.568-0800 [INFO]  cli: cmd/debug.go
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/project/copyright_year_only.hcl
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/project/full_project.hcl
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/project/license_only.hcl
2023-02-01T17:46:22.568-0800 [DEBUG] cli: skipping: config/testdata/project/partial_project.hcl
2023-02-01T17:46:22.568-0800 [INFO]  cli: cmd/dispatch.go
2023-02-01T17:46:22.568-0800 [INFO]  cli: cmd/report_repos.go
2023-02-01T17:46:22.568-0800 [INFO]  cli: cmd/license.go
2023-02-01T17:46:22.569-0800 [INFO]  cli: main.go
2023-02-01T17:46:22.569-0800 [INFO]  cli: teststuff/test.go
2023-02-01T17:46:22.569-0800 [INFO]  cli: repodata/repodata.go
Error: missing license header
exit status 1
```

https://hashicorp.atlassian.net/browse/ENGSYS2-562

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
