### PR TITLE
Support custom copyright holder

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ project {
   # Default: "MPL-2.0"
   license = "MPL-2.0"
 
+  # (OPTIONAL) Represents the copyright holder used in all statements
+  # Default: HashiCorp, Inc.
+  # copyright_holder = ""
+
   # (OPTIONAL) Represents the year that the project initially began
   # Default: <the year the repo was first created>
   # copyright_year = 0
@@ -185,7 +189,6 @@ It is often useful to introspect information about the state Copywrite finds
 itself in. The `copywrite debug` command can print the running configuration,
 whether or not a config file was loaded, what GitHub auth type is in use, and
 more. No sensitive information is printed, however.  
-
 
 ## Development
 

--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -36,7 +36,8 @@ config, see the "copywrite init" command.`,
 
 		// Map command flags to config keys
 		mapping := map[string]string{
-			`spdx`: `project.license`,
+			`spdx`:             `project.license`,
+			`copyright-holder`: `project.copyright_holder`,
 		}
 
 		// update the running config with any command-line flags
@@ -63,8 +64,9 @@ config, see the "copywrite init" command.`,
 		if conf.Project.License == "" {
 			cmd.Printf("The --spdx flag was not specified, omitting SPDX license statements.\n\n")
 		} else {
-			cmd.Printf("Using license identifier: %s\n\n", conf.Project.License)
+			cmd.Printf("Using license identifier: %s\n", conf.Project.License)
 		}
+		cmd.Printf("Using copyright holder: %v\n\n", conf.Project.CopyrightHolder)
 
 		if len(conf.Project.HeaderIgnore) == 0 {
 			cmd.Println("The project.header_ignore list was left empty in config. Processing all files by default.")
@@ -88,7 +90,7 @@ config, see the "copywrite init" command.`,
 		// Construct the configuration addLicense needs to properly format headers
 		licenseData := addlicense.LicenseData{
 			Year:   "", // by default, we don't include a year in copyright statements
-			Holder: "HashiCorp, Inc.",
+			Holder: conf.Project.CopyrightHolder,
 			SPDXID: conf.Project.License,
 		}
 
@@ -118,4 +120,5 @@ func init() {
 
 	// These flags will get mapped to keys in the the global Config
 	headersCmd.Flags().StringP("spdx", "s", "", "SPDX-compliant license identifier (e.g., 'MPL-2.0')")
+	headersCmd.Flags().StringP("copyright-holder", "c", "", "Copyright holder (default \"HashiCorp, Inc.\")")
 }

--- a/cmd/license.go
+++ b/cmd/license.go
@@ -33,8 +33,9 @@ var licenseCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Map command flags to config keys
 		mapping := map[string]string{
-			`spdx`: `project.license`,
-			`year`: `project.copyright_year`,
+			`spdx`:             `project.license`,
+			`year`:             `project.copyright_year`,
+			`copyright-holder`: `project.copyright_holder`,
 		}
 
 		// update the running config with any command-line flags
@@ -63,9 +64,10 @@ var licenseCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		cmd.Printf("Licensing under the following terms: %s\n", conf.Project.License)
-		cmd.Printf("Using year of initial copyright: %v\n\n", conf.Project.CopyrightYear)
+		cmd.Printf("Using year of initial copyright: %v\n", conf.Project.CopyrightYear)
+		cmd.Printf("Using copyright holder: %v\n\n", conf.Project.CopyrightHolder)
 
-		copyright := "Copyright (c) " + strconv.Itoa(conf.Project.CopyrightYear) + " HashiCorp, Inc."
+		copyright := "Copyright (c) " + strconv.Itoa(conf.Project.CopyrightYear) + " " + conf.Project.CopyrightHolder
 
 		licenseFiles, err := licensecheck.FindLicenseFiles(dirPath)
 		if err != nil {
@@ -172,4 +174,5 @@ func init() {
 	// TODO: eventually, the copyrightYear should be dynamically inferred from the repo
 	licenseCmd.Flags().IntP("year", "y", 0, "Year that the copyright statement should include")
 	licenseCmd.Flags().StringP("spdx", "s", "", "SPDX License Identifier indicating what the LICENSE file should represent")
+	licenseCmd.Flags().StringP("copyright-holder", "c", "", "Copyright holder (default \"HashiCorp, Inc.\")")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,10 @@ var (
 // Project represents data needed for copyright and licensing statements inside
 // a specific project/repo
 type Project struct {
-	CopyrightYear int      `koanf:"copyright_year"`
-	HeaderIgnore  []string `koanf:"header_ignore"`
-	License       string   `koanf:"license"`
+	CopyrightYear   int      `koanf:"copyright_year"`
+	CopyrightHolder string   `koanf:"copyright_holder"`
+	HeaderIgnore    []string `koanf:"header_ignore"`
+	License         string   `koanf:"license"`
 
 	// Upstream is optional and only used if a given repo pulls from another
 	Upstream string `koanf:"upstream"`
@@ -80,7 +81,8 @@ func New() (*Config, error) {
 
 	// Preload default config values
 	defaults := map[string]interface{}{
-		"schema_version": 1,
+		"schema_version":           1,
+		"project.copyright_holder": "HashiCorp, Inc.",
 	}
 	err := c.LoadConfMap(defaults)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,8 @@ func Test_New(t *testing.T) {
 
 		// Validate the default value(s)
 		assert.Equal(t, 1, actualOutput.SchemaVersion, "Schema Version defaults to 1")
-		assert.Equal(t, "schema_version -> 1\n", actualOutput.Sprint(), "Koanf object gets updated appropriately with defaults")
+		assert.Equal(t, "HashiCorp, Inc.", actualOutput.Project.CopyrightHolder, "Copyright Holder defaults to 'HashiCorp, Inc.'")
+		assert.Equal(t, "project.copyright_holder -> HashiCorp, Inc.\nschema_version -> 1\n", actualOutput.Sprint(), "Koanf object gets updated appropriately with defaults")
 	})
 }
 
@@ -44,8 +45,9 @@ func Test_LoadConfMap(t *testing.T) {
 		globalKoanf:   koanf.New(delim),
 		SchemaVersion: 12,
 		Project: Project{
-			CopyrightYear: 9001,
-			License:       "MPL-2.0",
+			CopyrightHolder: "HashiCorp, Inc.",
+			CopyrightYear:   9001,
+			License:         "MPL-2.0",
 		},
 		Dispatch: Dispatch{
 			IgnoredRepos: []string{
@@ -87,8 +89,9 @@ func Test_LoadCommandFlags(t *testing.T) {
 			expectedOutput: &Config{
 				SchemaVersion: 1,
 				Project: Project{
-					CopyrightYear: 9001,
-					License:       "MPL-2.0",
+					CopyrightHolder: "HashiCorp, Inc.",
+					CopyrightYear:   9001,
+					License:         "MPL-2.0",
 				},
 				Dispatch: Dispatch{
 					IgnoredRepos: []string{"foo", "bar"},
@@ -102,8 +105,9 @@ func Test_LoadCommandFlags(t *testing.T) {
 			expectedOutput: &Config{
 				SchemaVersion: 12,
 				Project: Project{
-					CopyrightYear: 9001,
-					License:       "MPL-2.0",
+					CopyrightHolder: "HashiCorp, Inc.",
+					CopyrightYear:   9001,
+					License:         "MPL-2.0",
 				},
 				Dispatch: Dispatch{
 					IgnoredRepos: []string{"foo", "bar"},
@@ -117,8 +121,9 @@ func Test_LoadCommandFlags(t *testing.T) {
 			expectedOutput: &Config{
 				SchemaVersion: 33,
 				Project: Project{
-					CopyrightYear: 9001,
-					License:       "MPL-2.0",
+					CopyrightHolder: "HashiCorp, Inc.",
+					CopyrightYear:   9001,
+					License:         "MPL-2.0",
 				},
 				Dispatch: Dispatch{
 					IgnoredRepos: []string{"foo", "bar"},
@@ -132,8 +137,9 @@ func Test_LoadCommandFlags(t *testing.T) {
 			expectedOutput: &Config{
 				SchemaVersion: 33,
 				Project: Project{
-					CopyrightYear: 9001,
-					License:       "MPL-2.0",
+					CopyrightHolder: "HashiCorp, Inc.",
+					CopyrightYear:   9001,
+					License:         "MPL-2.0",
 				},
 				Dispatch: Dispatch{
 					IgnoredRepos: []string{"foo", "bar"},
@@ -189,6 +195,15 @@ func Test_LoadConfigFile(t *testing.T) {
 		},
 		// Test Project-Related Configuration
 		{
+			description:  "File with project.copyright_holder populates accordingly",
+			inputCfgPath: "testdata/project/copyright_holder_only.hcl",
+			expectedOutput: &Config{
+				Project: Project{
+					CopyrightHolder: "Dummy Corporation",
+				},
+			},
+		},
+		{
 			description:  "File with project.copyright_year populates accordingly",
 			inputCfgPath: "testdata/project/copyright_year_only.hcl",
 			expectedOutput: &Config{
@@ -222,8 +237,9 @@ func Test_LoadConfigFile(t *testing.T) {
 			expectedOutput: &Config{
 				SchemaVersion: 12,
 				Project: Project{
-					CopyrightYear: 9001,
-					License:       "NOT_A_VALID_SPDX",
+					CopyrightYear:   9001,
+					CopyrightHolder: "Dummy Corporation",
+					License:         "NOT_A_VALID_SPDX",
 					HeaderIgnore: []string{
 						"asdf.go",
 						"*.css",
@@ -294,6 +310,7 @@ func Test_Sprint(t *testing.T) {
 			description:  "File with full project populates accordingly",
 			inputCfgPath: "testdata/project/full_project.hcl",
 			expectedOutput: strings.Join([]string{
+				"project.copyright_holder -> Dummy Corporation",
 				"project.copyright_year -> 9001",
 				"project.header_ignore -> [asdf.go *.css **/vendors/**.go]",
 				"project.license -> NOT_A_VALID_SPDX",

--- a/config/testdata/project/copyright_holder_only.hcl
+++ b/config/testdata/project/copyright_holder_only.hcl
@@ -1,0 +1,3 @@
+project {
+  copyright_holder = "Dummy Corporation"
+}

--- a/config/testdata/project/full_project.hcl
+++ b/config/testdata/project/full_project.hcl
@@ -1,8 +1,9 @@
 schema_version = 12
 
 project {
-  copyright_year = 9001
-  license        = "NOT_A_VALID_SPDX"
+  copyright_year   = 9001
+  copyright_holder = "Dummy Corporation"
+  license          = "NOT_A_VALID_SPDX"
 
   header_ignore = [
     "asdf.go",


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Fixes #26

This PR adds a `project.copyright_holder` configuration key that lets you manually set what copyright holder should be named inside of copyright headers and LICENSE files. This both unlocks some internal use cases, as well as makes it possible for those outside of HashiCorp to use the tool for their own use cases.

By default, the value is still `HashiCorp, Inc.`, but can be overriden either by a `--copyright-holder` / `-c` flag on the header and license commands, or by adding an entry to the `.copywrite.hcl` config.

The copyright headers appear as:
```
Copyright (c) <copyright_holder>
```

The header on the `LICENSE` file appears as:
```
Copyright (c) <copyright_year> <copyright_holder>
```

--

This value can be set via the `.copywrite.hcl` config as so:

```hcl
project {
  copyright_holder = "Dummy Corporation"
}
```


### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
https://hashicorp.atlassian.net/browse/ENGSYS2-536


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
