### PR TITLE
Update homebrew tap commit author

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,9 @@ brews:
       owner: hashicorp
       name: homebrew-tap
       branch: copywrite
+    commit_author:
+      name: ${{ secrets.commit_author_name }}
+      email: ${{ secrets.commit_author_email }}
     homepage: 'https://github.com/hashicorp/copywrite'
     description: 'copywrite -- utilities for managing copyright headers and license files for GitHub repos'
     license: 'MPL-2.0'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,8 +38,8 @@ brews:
       name: homebrew-tap
       branch: copywrite
     commit_author:
-      name: ${{ secrets.commit_author_name }}
-      email: ${{ secrets.commit_author_email }}
+      name: ${{ secrets.HOMEBREW_COMMIT_AUTHOR_NAME }}
+      email: ${{ secrets.HOMEBREW_COMMIT_EMAIL }}
     homepage: 'https://github.com/hashicorp/copywrite'
     description: 'copywrite -- utilities for managing copyright headers and license files for GitHub repos'
     license: 'MPL-2.0'


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
This is a small one to update Goreleaser so that it makes commits for `hashicorp/homebrew-tap` from a CLA-approved author (currently, me).

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
