### PR TITLE
Add suggested .vscode development settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "golang.go", // Enables rich Golang autocomplete and intellisense
+    "mechatroner.rainbow-csv", // Makes CSVs easier to read
+    "cschleiden.vscode-github-actions", // Provides autocomplete for GitHub Actions
+    "DavidAnson.vscode-markdownlint", // Markdown linting for consistency
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,44 @@
+{
+  // Editor settings
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  // json auto-formatting can get weird
+  "[json]": {
+    "editor.formatOnSave": false
+  },
+  // Go settings
+  "go.buildOnSave": "off",
+  "go.lintOnSave": "workspace",
+  "go.vetOnSave": "workspace",
+  "go.buildTags": "",
+  "go.buildFlags": [],
+  "go.lintTool": "golint",
+  "go.lintFlags": [],
+  "go.vetFlags": [],
+  "go.testOnSave": false,
+  "go.coverOnSave": false,
+  "go.useCodeSnippetsOnFunctionSuggest": true,
+  "go.formatTool": "gofmt",
+  "go.formatFlags": [],
+  "go.inferGopath": false,
+  "go.gocodeAutoBuild": false,
+  "go.testFlags": [
+    "-v"
+  ],
+  "cSpell.words": [
+    "addlicense",
+    "busa",
+    "checkonly",
+    "haya",
+    "headerignore",
+    "licensef",
+    "SPDXID"
+  ],
+  "markdownlint.ignore": [
+    ".github/pull_request_template.md"
+  ],
+  "markdownlint.config": {
+    "line-length": false
+  }
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Fixes #34 

When moving the copywrite project from an internal repo to this public one, the `.vscode/` directory was inadvertently left out. This PR brings things back in.

Quick aside - the `.vscode` folder is still a part of the gitignore, as some VS Code extensions occasionally dump sensitive info to that folder in logs (e.g., env vars). In this case, anything that should be tracked by git needs to be manually added via `git add .vscode/<file> -f`


### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
n/a

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
