### PR TITLE
Fix pattern comparison on windows

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"text/template"
 	"time"
@@ -294,6 +295,13 @@ func walk(ch chan<- *file, start string, logger *log.Logger) error {
 // Patterns are assumed to be valid.
 func fileMatches(path string, patterns []string) bool {
 	for _, p := range patterns {
+		
+		if runtime.GOOS == "windows" {
+			// If on windows, change path seperators to /
+			// in order for patterns to compare correctly 
+			path = filepath.ToSlash(path)
+		}
+		
 		// ignore error, since we assume patterns are valid
 		if match, _ := doublestar.Match(p, path); match {
 			return true


### PR DESCRIPTION
This commit uses filepath.ToSlash to ensure all paths use forward seperators if on Windows.

### :hammer_and_wrench: Description

The example `header_ignore` paths all use unix line endings which work fine so long as the paths compared are using unix path seperators. If this is run on Windows, filepath.Walk returns paths with Windows path seperators, which will appear different to doublestar.Match. It's safe to convert \ to / in place in this scenario, as these are valid paths.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->


### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
