### PR TITLE
Add SPDX-Copyright-Text tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,16 @@ repos:
   - repo: https://github.com/hashicorp/copywrite
     rev: v0.15.0 # Use any release tag
     hooks:
-      - id: copywrite-headers
+      - id: check-headers
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
         exclude: ^addLicense/testdata/
       - id: trailing-whitespace
         exclude: ^addLicense/testdata/
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: go-vet

--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -452,7 +452,7 @@ func hasLicense(b []byte) bool {
 	if len(b) < 1000 {
 		n = len(b)
 	}
-	return bytes.Contains(bytes.ToLower(b[:n]), []byte("copyright")) ||
+	return bytes.Contains(bytes.ToLower(b[:n]), []byte("spdx-filecopyrighttext")) ||
 		bytes.Contains(bytes.ToLower(b[:n]), []byte("mozilla public")) ||
 		bytes.Contains(bytes.ToLower(b[:n]), []byte("spdx-license-identifier"))
 }

--- a/addlicense/tmpl.go
+++ b/addlicense/tmpl.go
@@ -144,9 +144,9 @@ const tmplMPL = `This Source Code Form is subject to the terms of the Mozilla Pu
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.`
 
-const tmplSPDX = `Copyright (c){{ if .Year }} {{.Year}}{{ end }}{{ if .Holder }} {{.Holder}}{{ end }}
+const tmplSPDX = `SPDX-FileCopyrightText: Copyright (c){{ if .Year }} {{.Year}}{{ end }}{{ if .Holder }} {{.Holder}}{{ end }}
 {{ if .SPDXID }}SPDX-License-Identifier: {{.SPDXID}}{{ end }}`
 
-const tmplCopyrightOnly = `Copyright (c){{ if .Year }} {{.Year}}{{ end }}{{ if .Holder }} {{.Holder}}{{ end }}`
+const tmplCopyrightOnly = `SPDX-FileCopyrightText: Copyright (c){{ if .Year }} {{.Year}}{{ end }}{{ if .Holder }} {{.Holder}}{{ end }}`
 
 const spdxSuffix = "\n\nSPDX-License-Identifier: {{.SPDXID}}"


### PR DESCRIPTION
Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>

### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Prefix the copyright text with `SPDX-FileCopyrightText`.  This allows for easier machine parser of spdx data.

As a by-product of this it has highlight a bunch of extra files missing headers due to containing the word `copyright`.

I've updated the `.pre-commit-config.yaml` too.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
https://spdx.github.io/spdx-spec/v2.3/file-tags/#h2-file-tags-format

### :+1: Definition of Done

- [X] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark: It can, but there is an issue remaining that if the copyright text itself is change or entered incorrectly in a file (i.e. a line `SPDX-FileCopyrightText: bla`) the tool does not pick this up as an error.

<!-- if NO user :x: instead -->
