### PR TITLE
Support jest-environment directive

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -295,13 +295,13 @@ func walk(ch chan<- *file, start string, logger *log.Logger) error {
 // Patterns are assumed to be valid.
 func fileMatches(path string, patterns []string) bool {
 	for _, p := range patterns {
-		
+
 		if runtime.GOOS == "windows" {
 			// If on windows, change path seperators to /
-			// in order for patterns to compare correctly 
+			// in order for patterns to compare correctly
 			path = filepath.ToSlash(path)
 		}
-		
+
 		// ignore error, since we assume patterns are valid
 		if match, _ := doublestar.Match(p, path); match {
 			return true
@@ -412,6 +412,7 @@ var head = []string{
 	"<?php",                    // PHP opening tag
 	"# escape",                 // Dockerfile directive https://docs.docker.com/engine/reference/builder/#parser-directives
 	"# syntax",                 // Dockerfile directive https://docs.docker.com/engine/reference/builder/#parser-directives
+	"/** @jest-environment",    // Jest Environment string https://jestjs.io/docs/configuration#testenvironment-string
 }
 
 func hashBang(b []byte) []byte {

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -245,6 +245,7 @@ func TestAddLicense(t *testing.T) {
 		{"<?php\ncontent", "<?php\n// HYS\n\ncontent", true},
 		{"# escape: `\ncontent", "# escape: `\n// HYS\n\ncontent", true},
 		{"# syntax: docker/dockerfile:1.3\ncontent", "# syntax: docker/dockerfile:1.3\n// HYS\n\ncontent", true},
+		{"/** @jest-environment jsdom */\n content", "/** @jest-environment jsdom */\n// HYS\n\ncontent", true},
 
 		// ensure files with existing license or generated files are
 		// skipped. No need to test all permutations of these, since


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

From an internal report:

---

Our JS testing library, jest, has a feature to specify a test environment per-file using a comment at the top, like this:
```js
/**
 * @jest-environment jsdom
 */
```
Per [the docs](https://jestjs.io/docs/configuration#testenvironment-string), the heuristic here is:
> Any docblock pragmas in test files will be passed to the environment constructor and can be used for per-test configuration.

What's happening is that when the copyright header is added to the top of the file, it takes the place of the existing docblock and the jest-environment specification isn't respected:
```js
/**
 * Copyright (c) HashiCorp, Inc.
 * SPDX-License-Identifier: MPL-2.0
 */

/**
 * @jest-environment jsdom
 */
```

---

Given that the `@jest-environment` directive needs to be in the first docblock, this PR adds support for inline docblocks specifically using the `@jest-environment` directive.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
https://hashicorp.atlassian.net/browse/ENGSYS2-601


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
