### PR TITLE
refactor: update comment format for handlebars (.hbs) files

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -375,7 +375,7 @@ func licenseHeader(path string, tmpl *template.Template, data LicenseData) ([]by
 	case ".hs", ".sql", ".sdl":
 		lic, err = executeTemplate(tmpl, data, "", "-- ", "")
 	case ".hbs":
-		lic, err = executeTemplate(tmpl, data, "{{!--", "  ", "--}}")
+		lic, err = executeTemplate(tmpl, data, "{{!", "  ", "}}")
 	case ".html", ".htm", ".xml", ".vue", ".wxi", ".wxl", ".wxs":
 		lic, err = executeTemplate(tmpl, data, "<!--", " ", "-->")
 	case ".php":

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -335,7 +335,7 @@ func TestLicenseHeader(t *testing.T) {
 		},
 		{
 			[]string{"f.hbs"},
-			"{{!--\n  HYS\n--}}\n\n",
+			"{{!\n  HYS\n}}\n\n",
 		},
 		{
 			[]string{"f.html", "f.htm", "f.xml", "f.vue", "f.wxi", "f.wxl", "f.wxs"},


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
update comment format for handlebars (.hbs) files when inserting copyright headers

Changed from `{{!-- --}}` to `{{! }}` to satisfy teams using [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) for .hbs files.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests ~~added?~~ updated

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
