### PR TITLE
hbs: update comment to remove line break

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -375,7 +375,7 @@ func licenseHeader(path string, tmpl *template.Template, data LicenseData) ([]by
 	case ".hs", ".sql", ".sdl":
 		lic, err = executeTemplate(tmpl, data, "", "-- ", "")
 	case ".hbs":
-		lic, err = executeTemplate(tmpl, data, "{{!", "  ", "}}")
+		lic, err = executeTemplate(tmpl, data, "{{!", "  ", "~}}")
 	case ".html", ".htm", ".xml", ".vue", ".wxi", ".wxl", ".wxs":
 		lic, err = executeTemplate(tmpl, data, "<!--", " ", "-->")
 	case ".php":

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -335,7 +335,7 @@ func TestLicenseHeader(t *testing.T) {
 		},
 		{
 			[]string{"f.hbs"},
-			"{{!\n  HYS\n}}\n\n",
+			"{{!\n  HYS\n~}}\n\n",
 		},
 		{
 			[]string{"f.html", "f.htm", "f.xml", "f.vue", "f.wxi", "f.wxl", "f.wxs"},


### PR DESCRIPTION
### :hammer_and_wrench: Description

Template languages that generate HTML files, like Handlebars, are often sensitive to whitespace, so adding a line break [may change how a page is rendered](https://github.com/hashicorp/nomad/pull/16861).

This commit adds a `~` at the end of the comment as a [whitespace control](https://handlebarsjs.com/guide/expressions.html#whitespace-control) so the rendering engine removes the additional line break added by the license header comment.


### :link: External Links

[RELPLAT-703](https://hashicorp.atlassian.net/browse/RELPLAT-703?atlOrigin=eyJpIjoiMjg0ODBmZTdkYzgwNDFkYzkzM2I0NDMzZDFlZmY0MDUiLCJwIjoiaiJ9)


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->


[RELPLAT-703]: https://hashicorp.atlassian.net/browse/RELPLAT-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ