### PR TITLE
vendors -> vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ project {
   # files or folders should be ignored
   # Default: []
   header_ignore = [
-    # "vendors/**",
+    # "vendor/**",
     # "**autogen**",
   ]
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -139,7 +139,7 @@ project {
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   header_ignore = [
-    # "vendors/**",
+    # "vendor/**",
     # "**autogen**",
   ]
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -246,7 +246,7 @@ func Test_LoadConfigFile(t *testing.T) {
 					HeaderIgnore: []string{
 						"asdf.go",
 						"*.css",
-						"**/vendors/**.go",
+						"**/vendor/**.go",
 					},
 					Upstream: "hashicorp/super-secret-private-repo",
 				},
@@ -316,7 +316,7 @@ func Test_Sprint(t *testing.T) {
 			expectedOutput: strings.Join([]string{
 				"project.copyright_holder -> Dummy Corporation",
 				"project.copyright_year -> 9001",
-				"project.header_ignore -> [asdf.go *.css **/vendors/**.go]",
+				"project.header_ignore -> [asdf.go *.css **/vendor/**.go]",
 				"project.license -> NOT_A_VALID_SPDX",
 				"project.upstream -> hashicorp/super-secret-private-repo",
 				"schema_version -> 12\n",

--- a/config/testdata/project/full_project.hcl
+++ b/config/testdata/project/full_project.hcl
@@ -8,7 +8,7 @@ project {
   header_ignore = [
     "asdf.go",
     "*.css",
-    "**/vendors/**.go",
+    "**/vendor/**.go",
   ]
 
   upstream = "hashicorp/super-secret-private-repo"


### PR DESCRIPTION
### :hammer_and_wrench: Description

Updated the default configuration to ignore the `vendor` folder, rather than the `vendors` folder.

### :link: External Links

N/A


### :+1: Definition of Done

No new functionality added

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
