### PR TITLE
fix(gha): output headers cmd to stdout, not stderr

### DIFF
--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -105,6 +105,11 @@ config, see the "copywrite init" command.`,
 			// log prefix, e.g. logger.Println("[DEBUG] this is inferred as a debug log")
 			InferLevels: true,
 		})
+		// Redirect output to stdout to match the rest of the command output structure
+		// Ideally, we would differentiate inside the addlicense run, but in lieu of
+		// reworking the entire logging functionality there, this at least gets us
+		// consistency and fixes a race condition when using GitHub Action log groups
+		stdcliLogger.SetOutput(os.Stdout)
 
 		gha.StartGroup("The following files are missing headers:")
 		err := addlicense.Run(ignoredPatterns, "only", licenseData, "", verbose, plan, []string{"."}, stdcliLogger)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,9 @@ func init() {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&cfgPath, "config", ".copywrite.hcl", "config file")
+
+	// Let's make sure Cobra doesn't default to stderr
+	rootCmd.SetOut(os.Stdout)
 }
 
 func initConfig() {


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Previously, the GitHub Actions `::startgroup::` and `::endgroup` directives were being sent to stdout, but all command output from Copywrite was being sent to stderr. This caused an issue that was especially common for the `copywrite headers --plan` command, where the list of files missing headers would be partially included and partially excluded from the logging group.

As a fix I set Cobra up to print to stdout by default, and updated the logger we send to the addlicense module to also use stdout. Ideally, we'd restructure logging entirely within the module, but I'm leaving that for a future PR.


### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
#79 

### :+1: Definition of Done

- [x] New functionality works?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
