### PR TITLE
Add support for .lr and .lr.go files

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -364,7 +364,7 @@ func licenseHeader(path string, tmpl *template.Template, data LicenseData) ([]by
 		lic, err = executeTemplate(tmpl, data, "/*", " * ", " */")
 	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".ts":
 		lic, err = executeTemplate(tmpl, data, "/**", " * ", " */")
-	case ".cc", ".cpp", ".cs", ".go", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv":
+	case ".cc", ".cpp", ".cs", ".go", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv", ".lr":
 		lic, err = executeTemplate(tmpl, data, "", "// ", "")
 	case ".py", ".sh", ".bash", ".zsh", ".yaml", ".yml", ".dockerfile", "dockerfile", ".rb", "gemfile", ".ru", ".tcl", ".hcl", ".tf", ".tfvars", ".nomad", ".bzl", ".pl", ".pp", ".ps1", ".psd1", ".psm1":
 		lic, err = executeTemplate(tmpl, data, "", "# ", "")

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -314,7 +314,7 @@ func TestLicenseHeader(t *testing.T) {
 		},
 		{
 			[]string{"f.cc", "f.cpp", "f.cs", "f.go", "f.hh", "f.hpp", "f.m", "f.mm", "f.proto",
-				"f.rs", "f.swift", "f.dart", "f.groovy", "f.v", "f.sv", "f.php"},
+				"f.rs", "f.swift", "f.dart", "f.groovy", "f.v", "f.sv", "f.php", "f.lr"},
 			"// HYS\n\n",
 		},
 		{


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add new file extensions to also support license headers for `.lr` and `.lr.go` files.


### :link: External Links

We use it in this repo: https://github.com/mondoohq/cnquery


### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:

