### PR TITLE
Address deprecated goreleaser configuration

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -69,10 +69,10 @@ jobs:
           go-version-file: '.go-version'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --rm-dist --skip-publish --snapshot
+          args: release --clean --skip-publish --snapshot
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,8 +19,12 @@ builds:
       - -s -w -X github.com/hashicorp/copywrite/cmd.version={{.Version}} -X github.com/hashicorp/copywrite/cmd.commit={{.ShortCommit}}
     binary: copywrite
 archives:
-  - replacements:
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip
@@ -36,7 +40,7 @@ release:
 # Auto-publish to the HashiCorp homebrew tap: https://github.com/hashicorp/homebrew-tap
 brews:
   - name: copywrite
-    tap:
+    repository:
       owner: hashicorp
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
- update go-releaser in ci
- remove deprecated bits from goreleaser config

### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
recent updates from goreleaser made parts of our `.goreleaser.yaml` invalid. These changes address the deprecations found in https://goreleaser.com/deprecations/#brewstap, and will get our build and release pipeline back to green.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->


### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
