### PR TITLE
Revert release naming to align with prior format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 .vscode
 .DS_Store
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,9 +21,9 @@ builds:
 archives:
   - name_template: >-
       {{- .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows


### PR DESCRIPTION
### :hammer_and_wrench: Description

actions/setup-copywrite relies on the [specific name](https://github.com/hashicorp/setup-copywrite/blob/main/action.js#L65) format. Note: the `s/amd64/x86_64/g` behavior is a historical artifact, we could update it in the future if we coordinate with the action.

Error:

```
Run hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
Error: Unable to find asset matching copywrite_0.16.5_linux_x86_64.tar.gz in the v0.16.5 release
```

After this change:
```
  • archives
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_windows_x86_64.zip
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_linux_x86_64.tar.gz
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_darwin_x86_64.tar.gz
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_darwin_arm64.tar.gz
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_linux_arm64.tar.gz
    • creating                                       archive=dist/copywrite_0.16.5-SNAPSHOT-52379d7_windows_arm64.zip
```
nit: Also adding `dist/` to our ignores

### :link: External Links

Partial revert of changes made in PR #98

### :+1: Definition of Done

- [x] New functionality works?
- [ ] ~Tests added?~

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
