### PR TITLE
fix(logging): respect log levels for skipped files

### DIFF
--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -105,11 +105,12 @@ config, see the "copywrite init" command.`,
 			// log prefix, e.g. logger.Println("[DEBUG] this is inferred as a debug log")
 			InferLevels: true,
 		})
-		// Redirect output to stdout to match the rest of the command output structure
-		// Ideally, we would differentiate inside the addlicense run, but in lieu of
-		// reworking the entire logging functionality there, this at least gets us
-		// consistency and fixes a race condition when using GitHub Action log groups
-		stdcliLogger.SetOutput(os.Stdout)
+
+		// WARNING: because of the way we redirect cliLogger to os.Stdout, anything
+		// prefixed with "[ERROR]" will not implicitly be written to stderr.
+		// However, we propagate errors upward from addlicense and then run a
+		// cobra.CheckErr on the return, which will indeed output to stderr and
+		// return a non-zero error code.
 
 		gha.StartGroup("The following files are missing headers:")
 		err := addlicense.Run(ignoredPatterns, "only", licenseData, "", verbose, plan, []string{"."}, stdcliLogger)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,8 +96,9 @@ func initLogger() {
 
 	hclog.Default().Named("cli")
 	cliLogger = hclog.New(&hclog.LoggerOptions{
-		Name:  "cli",
-		Level: logLevel,
-		Color: hclog.AutoColor,
+		Name:   "cli",
+		Level:  logLevel,
+		Color:  hclog.AutoColor,
+		Output: os.Stdout,
 	})
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Previously, the `copywrite headers` command would output a lot of `[DEBUG] skipping file...` statements, esp. when large folders were excluded (looking at you, `NODE_MODULES`). This made for a poor experience, and was a bug introduced when I made #80 - as in an attempt to fix an issue with GHA log group directives and addlicense sending to stdout and stderr, respectively, I introduced a bug that ignored the `COPYWRITE_LOG_LEVEL` env var.

This PR fixes that error while ensuring the GHA log grouping still works by redirecting the `cliLogger` we use throughout the headers cmd (and others) to stdout by default. This doesn't appear to be a large shift or change for other commands, but does make a big difference for the headers command.

### :+1: Definition of Done

- [x] New functionality works?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
