### PR TITLE
Revert #59

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -375,7 +375,7 @@ func licenseHeader(path string, tmpl *template.Template, data LicenseData) ([]by
 	case ".hs", ".sql", ".sdl":
 		lic, err = executeTemplate(tmpl, data, "", "-- ", "")
 	case ".hbs":
-		lic, err = executeTemplate(tmpl, data, "{{!", "  ", "~}}")
+		lic, err = executeTemplate(tmpl, data, "{{!", "  ", "}}")
 	case ".html", ".htm", ".xml", ".vue", ".wxi", ".wxl", ".wxs":
 		lic, err = executeTemplate(tmpl, data, "<!--", " ", "-->")
 	case ".php":

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -335,7 +335,7 @@ func TestLicenseHeader(t *testing.T) {
 		},
 		{
 			[]string{"f.hbs"},
-			"{{!\n  HYS\n~}}\n\n",
+			"{{!\n  HYS\n}}\n\n",
 		},
 		{
 			[]string{"f.html", "f.htm", "f.xml", "f.vue", "f.wxi", "f.wxl", "f.wxs"},


### PR DESCRIPTION
### :hammer_and_wrench: Description

The change introduced in #59 caused Babel to leave endless traces of error across our products (I encounter them on a regular basis in `nomad`, `vault`, `design-system`, `cloud-ui`).

The error is always the same

```sh
unexpectedly found "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: BUSL-1.1\n~" when slicing source, but expected "\n  Copyright (c) HashiCorp, Inc.\n  SPDX-License-Identifier: BUSL-1.1\n"
```

The root cause is in `ember-template-compiler`, as mentioned in https://github.com/hashicorp/copywrite/pull/59#issuecomment-1711802021 but until that gets sorted (if it ever gets sorted) we should be preserving the non-white-space-trimming syntax.

I understand this format may have side effects in whitespace-sensitive templates, but these isolated cases can be addressed individually, rather than leaving long traces of compiler errors.

Leaving this here for your consideration.

![2023-11-27 at 10 45 04](https://github.com/hashicorp/copywrite/assets/788096/91218e6d-0b19-4fe4-9903-b82eb4bf824c)

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
