### PR TITLE
Ignore node_modules subdirectories

### DIFF
--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -86,7 +86,7 @@ config, see the "copywrite init" command.`,
 		autoSkippedPatterns := []string{
 			".github/workflows/**",
 			".github/dependabot.yml",
-			"**node_modules/**",
+			"**/node_modules/**",
 		}
 		ignoredPatterns := lo.Union(conf.Project.HeaderIgnore, autoSkippedPatterns)
 


### PR DESCRIPTION
This adjusts the default ignore pattern for node_modules to include subdirectories when checking for headers. This is necessary because the node_modules directory is sometimes nested within other directories, and the current pattern only matches the top-level node_modules directory.

This really only affects interactive use, as node_modules directories are not usally committed to version control.
