### PR TITLE
Allow setting copyright year

### DIFF
--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/copywrite/addlicense"
 	"github.com/hashicorp/go-hclog"
@@ -41,6 +42,7 @@ config, see the "copywrite init" command.`,
 		mapping := map[string]string{
 			`spdx`:             `project.license`,
 			`copyright-holder`: `project.copyright_holder`,
+			`copyright-year`:   `project.copyright_year`,
 		}
 
 		// update the running config with any command-line flags
@@ -91,8 +93,12 @@ config, see the "copywrite init" command.`,
 		ignoredPatterns := lo.Union(conf.Project.HeaderIgnore, autoSkippedPatterns)
 
 		// Construct the configuration addLicense needs to properly format headers
+		var yearStr string
+		if conf.Project.CopyrightYear > 0 {
+			yearStr = strconv.Itoa(conf.Project.CopyrightYear)
+		}
 		licenseData := addlicense.LicenseData{
-			Year:   "", // by default, we don't include a year in copyright statements
+			Year:   yearStr,
 			Holder: conf.Project.CopyrightHolder,
 			SPDXID: conf.Project.License,
 		}
@@ -130,4 +136,5 @@ func init() {
 	// These flags will get mapped to keys in the the global Config
 	headersCmd.Flags().StringP("spdx", "s", "", "SPDX-compliant license identifier (e.g., 'MPL-2.0')")
 	headersCmd.Flags().StringP("copyright-holder", "c", "", "Copyright holder (default \"HashiCorp, Inc.\")")
+	headersCmd.Flags().IntP("copyright-year", "y", 0, "Copyright year (default: 0 (empty))")
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

Make use of the `copyright_year` configuration field and allow overriding it at runtime via command flag. This way users that want the old behaviour can simply ensure that they are not setting the `copyright_year` in the config file.

For the rest of the users this enables a variety of new usage patterns, for example:
- Use `copyright_year` in the configuration file to capture the project creation date (the one used during the initial invocation of `copywrite headers`)
- Use `-y`/`--copyright-year` flag in various dev automation tools to stamp new source files with the year they were first created.


### :link: External Links

N/A


### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
