### PR TITLE
fix(pre-commit): Hooks should use the copywrite binary

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,27 +1,27 @@
 - id: add-headers
   name: Add copyright headers
   description: Adds missing copyright headers to all source code files
-  entry: go run .
+  entry: copywrite headers
   language: golang
-  args: [headers]
+  pass_filenames: false
 
 - id: check-headers
   name: Validate copyright headers
   description: Checks if any copyright headers are missing, but does not make changes
-  entry: go run .
+  entry: copywrite headers --plan
   language: golang
-  args: [headers --plan]
+  pass_filenames: false
 
 - id: add-license
   name: Add or fix repo license
   description: Adds or updates a non-compliant LICENSE file
-  entry: go run .
+  entry: copywrite license
   language: golang
-  args: [license]
+  pass_filenames: false
 
 - id: check-license
   name: Validate repo license
   description: Checks if a LICENSE file is valid, but does not make changes
-  entry: go run .
+  entry: copywrite license --plan
   language: golang
-  args: [license --plan]
+  pass_filenames: false


### PR DESCRIPTION
If you use copywrite in your repo, you probably already have copywrite installed.

The hooks running `go run .` doesn't work in my terraform provider, because it is a plugin:

```
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically
exit status 1
```

So switch the entry point to be the copywrite program. Don't pass filenames. copywrite knows what to do.

Pass arguments directly on the entry.

Closes #78
