### PR TITLE
fix(goreleaser): Fix deprecation on format -> formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 checksum:
   name_template: 'SHA256SUMS'
 release:


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesformat

### :hammer_and_wrench: Description

From goreleaser logs:

```
  • setting defaults
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```

### :link: External Links

https://goreleaser.com/deprecations/#archivesformat


### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
