### PR TITLE
fix(.pre-commit-config.yaml): fix hook id to match new name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - repo: https://github.com/hashicorp/copywrite
     rev: v0.15.0 # Use any release tag
     hooks:
-      - id: copywrite-headers
+      - id: add-headers
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:


### PR DESCRIPTION
### :hammer_and_wrench: Description

`.pre-comit-config.yaml`, for some reason referred to a hook (`copywrite-headers`) which was not described in `.pre-commit-hooks.yaml`. I have no idea why this was the case, but changed it to make use of the `add-headers` hook which is in fact defined. 


### :link: External Links

<!-- JIRA Issues, RFC, etc. -->


### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->
