### PR TITLE
Dynamic license terms

### DIFF
--- a/LicenceTerms.json
+++ b/LicenceTerms.json
@@ -1,0 +1,5 @@
+[
+		"hashicorp, inc.",
+		"mozilla public",
+		"spdx-license-identifier",
+]

--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -488,7 +488,27 @@ func hasLicense(b []byte) bool {
 	if len(b) < 1000 {
 		n = len(b)
 	}
-	return bytes.Contains(bytes.ToLower(b[:n]), []byte("copyright")) ||
-		bytes.Contains(bytes.ToLower(b[:n]), []byte("mozilla public")) ||
-		bytes.Contains(bytes.ToLower(b[:n]), []byte("spdx-license-identifier"))
+
+	// Default conditions
+	defaultTerms := []string{"copyright", "mozilla public", "spdx-license-identifier"}
+
+	// Load conditions from config file
+	configPath := "../LicenceCopywrite.json"
+	file, err := os.ReadFile(configPath)
+	if err == nil {
+		var customTerms []string
+		if json.Unmarshal(file, &customTerms) == nil && len(customTerms) > 0 {
+			defaultTerms = customTerms
+		}
+	}
+
+	// Check for license terms
+	content := bytes.ToLower(b[:n])
+	for _, term := range defaultTerms {
+		if bytes.Contains(content, []byte(strings.ToLower(term))) {
+			return true
+		}
+	}
+	return false
 }
+

--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -490,7 +490,7 @@ func hasLicense(b []byte) bool {
 	}
 
 	// Default conditions
-	defaultTerms := []string{"copyright", "mozilla public", "spdx-license-identifier"}
+	defaultTerms := []string{"hashicorp, inc.", "mozilla public", "spdx-license-identifier"}
 
 	// Load conditions from config file
 	configPath := "../LicenceCopywrite.json"


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Updated `hasLicense` function to dynamically load license terms from `../LicenceTerms.json`.  
- Falls back to default terms if the file is missing or has invalid JSON.  
- Ensures no additional functions are introduced for simplicity and maintainability.  

### :link: External Links

- [Issue #2453](https://github.com/opentofu/opentofu/issues/2453)  

### :+1: Definition of Done

- [ ] New functionality works?  
- [ ] Tests added?  

### :thinking: Can be merged upon approval?  

:white_check_mark:
