### PR TITLE
[Chore] - add .gjs and .gts files

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -361,7 +361,7 @@ func licenseHeader(path string, tmpl *template.Template, data LicenseData) ([]by
 	switch fileExtension(base) {
 	case ".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts":
 		lic, err = executeTemplate(tmpl, data, "/*", " * ", " */")
-	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".ts":
+	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".ts", ".gjs", ".gts":
 		lic, err = executeTemplate(tmpl, data, "/**", " * ", " */")
 	case ".cc", ".cpp", ".cs", ".go", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv", ".lr":
 		lic, err = executeTemplate(tmpl, data, "", "// ", "")

--- a/addlicense/main_test.go
+++ b/addlicense/main_test.go
@@ -308,7 +308,7 @@ func TestLicenseHeader(t *testing.T) {
 			"/*\n * HYS\n */\n\n",
 		},
 		{
-			[]string{"f.js", "f.mjs", "f.cjs", "f.jsx", "f.tsx", "f.css", "f.scss", "f.sass", "f.ts"},
+			[]string{"f.js", "f.mjs", "f.cjs", "f.jsx", "f.tsx", "f.css", "f.scss", "f.sass", "f.ts", "f.gjs", "f.gts"},
 			"/**\n * HYS\n */\n\n",
 		},
 		{


### PR DESCRIPTION
### :hammer_and_wrench: Description
This PR adds support for `.gjs` and `.gts` file types. These should be treated the same as `.js` and `.ts` files.

[reference](https://github.com/ember-cli/ember-template-imports)
### :link: External Links


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?

### :thinking: Can be merged upon approval?
Yes

:white_check_mark:
<!-- if NO user :x: instead -->
