### PR TITLE
fix: skip ignored directories early during file walk

### DIFF
--- a/addlicense/main.go
+++ b/addlicense/main.go
@@ -307,6 +307,10 @@ func walk(ch chan<- *file, start string, logger *log.Logger) error {
 			return nil
 		}
 		if fi.IsDir() {
+			if path != start && FileMatches(path, ignorePatterns) {
+				logger.Printf("[DEBUG] skipping directory: %s", path)
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		// Skip symlinks — broken symlinks cause os.ReadFile to fail with

--- a/cmd/headers.go
+++ b/cmd/headers.go
@@ -259,7 +259,13 @@ func updateExistingHeaders(cmd *cobra.Command, ignoredPatterns []string, dryRun 
 				return nil
 			}
 
-			if err != nil || d.IsDir() {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if path != "." && addlicense.FileMatches(path, ignoredPatterns) {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 


### PR DESCRIPTION

Previously, ignore patterns were only checked against files — the walk still descended into every directory unconditionally. This meant a directory like `.venv` with thousands of files was fully traversed before each file was individually filtered out, causing significant slowdowns.

Now, when a directory itself matches an ignore pattern, `filepath.SkipDir` is returned immediately, pruning the entire subtree in one step regardless of how many files are inside.

### :hammer_and_wrench: Description

**What was broken:**

The file walk in both `addlicense/main.go` and `cmd/headers.go` only applied ignore pattern checks to files. When the walk encountered a directory, it always returned `nil` and descended into it unconditionally. This meant a directory like `.venv` with thousands of Python files was fully traversed — visiting every file, checking each one against the pattern, and then discarding it. The cost scaled linearly with the number of files in the ignored directory.

**What changed:**

Added a directory-level ignore check in both walk functions. When a directory path matches an ignore pattern, `filepath.SkipDir` is returned immediately, telling the OS not to read the directory's children at all. The `path != start` / `path != "."` guard ensures the root directory itself is never accidentally skipped.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->

### :+1: Definition of Done

- [x] New functionality works? — verified across 17 test scenarios including directory skipping, nested patterns, and all pre-existing header behaviours
- [x] Tests added? — all existing tests pass; manual regression suite run below

## Test Results

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| A | All headers correct, LICENSE up to date | No changes | ✅ Clean |
| B | Source file missing header, LICENSE already at current year | Header added, LICENSE untouched | ✅ Pass |
| C | Source file missing header, LICENSE behind (2025) | Header added + LICENSE bumped | ✅ Pass |
| D | Source file year outdated (2025), LICENSE behind | Both year-bumped to current year | ✅ Pass |
| E | `--plan` mode with missing header | Shows what would change, writes nothing | ✅ Pass |
| F | `--plan` mode with everything correct | No output, writes nothing | ✅ Clean |
| G | No LICENSE file in repo | Runs cleanly, no crash | ✅ Pass |
| H | Mixed — correct, missing, outdated in same repo | Only affected files changed, correct file untouched | ✅ Pass |
| I | `ignore_year1=true`, single-year headers already correct | No changes | ✅ Clean |
| J | Idempotency — run once then run again immediately | Second run always produces zero changes | ✅ Pass |
| K | Existing header year outdated, no missing headers (step 1 only) | Year bumped in source + LICENSE | ✅ Pass |
| L | Copyright holder mismatch (e.g. HashiCorp → Acme) | Holder updated, LICENSE untouched if already current year | ✅ Pass |
| M | `.venv` in `header_ignore`, 100 files inside | Files inside `.venv` not touched | ✅ Pass |
| N | Multiple ignored dirs (`vendor/**` + `**/node_modules/**`) | Neither directory traversed | ✅ Pass |
| O | Ignored dir alongside a source file missing a header | Source file updated, ignored dir untouched | ✅ Pass |
| P | Nested ignored dir (`**/vendor/**` inside a subdirectory) | Nested dir skipped correctly | ✅ Pass |
| Q | 200 files in `.venv` — verify single skip log entry | `skipping directory: .venv` appears exactly once | ✅ Pass |

### :thinking: Can be merged upon approval?

:white_check_mark:

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request. — simple `git revert`; no schema, data, or config changes involved.
- [x] If applicable, I've documented the impact of any changes to security controls. — no security controls affected; this is a performance fix in directory traversal logic only.

