### PR TITLE
fix(docs): Correct pre-commit hook id

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ snippet to your repo's `.pre-commit-config.yaml`:
   - repo: https://github.com/hashicorp/copywrite
     rev: v0.15.0 # Use any release tag
     hooks:
-      - id: copywrite-headers
+      - id: add-headers
 ```
 
 ## Debugging
@@ -258,7 +258,7 @@ The `COPYWRITE_LOG_LEVEL` setting takes precedence, however.
 It is often useful to introspect information about the state Copywrite finds
 itself in. The `copywrite debug` command can print the running configuration,
 whether or not a config file was loaded, what GitHub auth type is in use, and
-more. No sensitive information is printed, however.  
+more. No sensitive information is printed, however.
 
 ## Development
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Update the README with the correct pre-commit id. If someone uses the example code listed, an error is produced:
```console
❯ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/hashicorp/copywrite.
[ERROR] `copywrite-headers` is not present in repository https://github.com/hashicorp/copywrite.  Typo? Perhaps it is introduced in a newer version?  Often `pre-commit autoupdate` fixes this.
```
- Remove trailing whitespace in README

### :+1: Definition of Done

- [X] Simple documentation update

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
