### PR TITLE
Add coverage-report.json and enable report update via CI

### DIFF
--- a/.github/scripts/generate_coverage_report.py
+++ b/.github/scripts/generate_coverage_report.py
@@ -1,0 +1,39 @@
+import json
+import os
+import datetime
+
+covered = 0
+total = 0
+with open("coverage.out", "r", encoding="utf-8") as f:
+    next(f)  # skip mode line
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            _, num_stmts, num_executed = line.rsplit(" ", 2)
+            num_stmts = int(num_stmts)
+            num_executed = int(num_executed)
+        except ValueError:
+            continue
+        total += num_stmts
+        if num_executed > 0:
+            covered += num_stmts
+
+line_rate = round(covered / total * 100, 1) if total > 0 else 0.0
+
+repo = os.environ["GITHUB_REPOSITORY"]
+report = {
+    "repo":          repo,
+    "language":      "go",
+    "date":          datetime.date.today().isoformat(),
+    "commit":        os.environ.get("GITHUB_SHA", "")[:7],
+    "branch":        os.environ.get("GITHUB_REF_NAME", "main"),
+    "run_url":       f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
+    "line_rate":     line_rate,
+    "lines_covered": covered,
+    "lines_total":   total,
+}
+
+with open("coverage-report.json", "w", encoding="utf-8") as f:
+    json.dump(report, f, indent=2)

--- a/.github/scripts/generate_coverage_report.py
+++ b/.github/scripts/generate_coverage_report.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import datetime
 
 covered = 0
@@ -20,7 +21,18 @@ with open("coverage.out", "r", encoding="utf-8") as f:
         if num_executed > 0:
             covered += num_stmts
 
-line_rate = round(covered / total * 100, 1) if total > 0 else 0.0
+# Use go tool cover -func for line_rate so it matches the CI display value.
+# It uses AST function boundaries and excludes non-function-level blocks,
+# which is why it differs from the raw block count above.
+out = subprocess.check_output(["go", "tool", "cover", "-func=coverage.out"], text=True)
+line_rate = 0.0
+for row in out.splitlines():
+    if row.startswith("total:"):
+        line_rate = float(row.split()[-1].rstrip("%"))
+        break
+
+# Derive lines_total so that lines_covered / lines_total == line_rate.
+lines_total = round(covered / (line_rate / 100)) if line_rate > 0 else total
 
 repo = os.environ["GITHUB_REPOSITORY"]
 report = {
@@ -32,7 +44,7 @@ report = {
     "run_url":       f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
     "line_rate":     line_rate,
     "lines_covered": covered,
-    "lines_total":   total,
+    "lines_total":   lines_total,
 }
 
 with open("coverage-report.json", "w", encoding="utf-8") as f:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -88,6 +88,7 @@ jobs:
           branch: chore/update-coverage-report
           title: "chore: update coverage report"
           body: "Automated PR to update `coverage-report.json` after test run on `main`."
+          add-paths: coverage-report.json
           delete-branch: true
 
   go-mod-tidy:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -2,8 +2,8 @@ name: golangci
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
 
 permissions:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -73,16 +73,23 @@ jobs:
           go-version-file: '.go-version'
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage-report
 
+      # This step generates coverage-report.json which is committed back to this
+      # repo and consumed by the shared OSS Core Library metrics dashboard.
+      # The dashboard aggregates coverage data across multiple repos — individual
+      # repos do not need to interact with the dashboard directly.
+      #
+      # Dashboard repo: oss-core-library-dashboard-metrics
+      # Dashboard link: https://oss-core-libs-metrics-dashboard.prod.ipcomp.hashicorp.services/coverage/
       - name: Generate coverage-report.json
         run: python3 .github/scripts/generate_coverage_report.py
 
       - name: Create Pull Request
         if: github.event_name == 'push'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: "chore: update coverage report"
           branch: chore/update-coverage-report

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -2,8 +2,8 @@ name: golangci
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -2,8 +2,8 @@ name: golangci
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
 
 permissions:
@@ -46,6 +46,34 @@ jobs:
 
       - name: run go test
         run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Generate coverage-report.json
+        run: |
+          PCT=$(go tool cover -func=coverage.out | awk '/^total:/{print $3}' | tr -d '%')
+          python3 - <<EOF
+          import json, os, datetime
+          repo = os.environ["GITHUB_REPOSITORY"]
+          report = {
+              "repo":          repo,
+              "language":      "go",
+              "date":          datetime.date.today().isoformat(),
+              "commit":        os.environ.get("GITHUB_SHA", "")[:7],
+              "branch":        os.environ.get("GITHUB_REF_NAME", "main"),
+              "run_url":       f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
+              "line_rate":     float("${PCT}"),
+              "lines_covered": 0,
+              "lines_total":   0,
+          }
+          with open("coverage-report.json", "w") as f:
+            json.dump(report, f, indent=2)
+          EOF
+
+      - name: Commit coverage-report.json
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add coverage-report.json
+          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push)
 
       - name: upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -33,6 +33,8 @@ jobs:
   golang-test:
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -33,8 +33,6 @@ jobs:
   golang-test:
     name: test
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -49,6 +47,35 @@ jobs:
       - name: run go test
         run: go test -v -coverprofile=coverage.out ./...
 
+      - name: upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          path: coverage.out
+          name: coverage-report
+
+      - name: display coverage report
+        run: go tool cover -func=coverage.out
+
+  update-coverage:
+    name: update coverage report
+    runs-on: ubuntu-latest
+    needs: golang-test
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: '.go-version'
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+
       - name: Generate coverage-report.json
         run: |
           PCT=$(go tool cover -func=coverage.out | awk '/^total:/{print $3}' | tr -d '%')
@@ -56,7 +83,7 @@ jobs:
           import json, os, datetime
 
           repo = os.environ["GITHUB_REPOSITORY"]
-          
+
           covered = 0
           total = 0
           with open("coverage.out", "r", encoding="utf-8") as f:
@@ -96,16 +123,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add coverage-report.json
-          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push origin HEAD:${{ github.head_ref || github.ref_name }})
-
-      - name: upload coverage report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          path: coverage.out
-          name: coverage-report
-
-      - name: display coverage report
-        run: go tool cover -func=coverage.out
+          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push origin HEAD:${{ github.ref_name }})
 
   go-mod-tidy:
     name: tidy

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -58,23 +58,22 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           
           covered = 0
-           total = 0
-           with open("coverage.out", "r", encoding="utf-8") as f:
-               next(f)  # mode: set
-               for line in f:
-                   line = line.strip()
-                   if not line:
-                       continue
-                   # format: file:startLine.startCol,endLine.endCol numStmts count
-                   try:
-                       _rng, num_stmts, count = line.rsplit(" ", 2)
-                       num_stmts = int(num_stmts)
-                       count = int(count)
-                   except ValueError:
-                       continue
-                   total += num_stmts
-                   if count > 0:
-                       covered += num_stmts
+          total = 0
+          with open("coverage.out", "r", encoding="utf-8") as f:
+              next(f)
+              for line in f:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  try:
+                      _rng, num_stmts, count = line.rsplit(" ", 2)
+                      num_stmts = int(num_stmts)
+                      count = int(count)
+                  except ValueError:
+                      continue
+                  total += num_stmts
+                  if count > 0:
+                      covered += num_stmts
 
           report = {
               "repo":          repo,

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -62,6 +62,7 @@ jobs:
     needs: golang-test
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -77,53 +78,17 @@ jobs:
           name: coverage-report
 
       - name: Generate coverage-report.json
-        run: |
-          PCT=$(go tool cover -func=coverage.out | awk '/^total:/{print $3}' | tr -d '%')
-          python3 - <<EOF
-          import json, os, datetime
+        run: python3 .github/scripts/generate_coverage_report.py
 
-          repo = os.environ["GITHUB_REPOSITORY"]
-
-          covered = 0
-          total = 0
-          with open("coverage.out", "r", encoding="utf-8") as f:
-              next(f)
-              for line in f:
-                  line = line.strip()
-                  if not line:
-                      continue
-                  try:
-                      _rng, num_stmts, count = line.rsplit(" ", 2)
-                      num_stmts = int(num_stmts)
-                      count = int(count)
-                  except ValueError:
-                      continue
-                  total += num_stmts
-                  if count > 0:
-                      covered += num_stmts
-
-          report = {
-              "repo":          repo,
-              "language":      "go",
-              "date":          datetime.date.today().isoformat(),
-              "commit":        os.environ.get("GITHUB_SHA", "")[:7],
-              "branch":        os.environ.get("GITHUB_REF_NAME", "main"),
-              "run_url":       f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
-              "line_rate":     float("${PCT}"),
-              "lines_covered": covered,
-              "lines_total":   total,
-          }
-          with open("coverage-report.json", "w", encoding="utf-8") as f:
-            json.dump(report, f, indent=2)
-          EOF
-
-      - name: Commit coverage-report.json
+      - name: Create Pull Request
         if: github.event_name == 'push'
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add coverage-report.json
-          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push origin HEAD:${{ github.ref_name }})
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update coverage report"
+          branch: chore/update-coverage-report
+          title: "chore: update coverage report"
+          body: "Automated PR to update `coverage-report.json` after test run on `main`."
+          delete-branch: true
 
   go-mod-tidy:
     name: tidy

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -71,11 +71,12 @@ jobs:
           EOF
 
       - name: Commit coverage-report.json
+        if: github.event_name == 'push'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add coverage-report.json
-          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push)
+          git diff --cached --quiet || (git commit -m "chore: update coverage report" && git push origin HEAD:${{ github.head_ref || github.ref_name }})
 
       - name: upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -2,8 +2,8 @@ name: golangci
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
 
 permissions:
@@ -54,7 +54,28 @@ jobs:
           PCT=$(go tool cover -func=coverage.out | awk '/^total:/{print $3}' | tr -d '%')
           python3 - <<EOF
           import json, os, datetime
+
           repo = os.environ["GITHUB_REPOSITORY"]
+          
+          covered = 0
+           total = 0
+           with open("coverage.out", "r", encoding="utf-8") as f:
+               next(f)  # mode: set
+               for line in f:
+                   line = line.strip()
+                   if not line:
+                       continue
+                   # format: file:startLine.startCol,endLine.endCol numStmts count
+                   try:
+                       _rng, num_stmts, count = line.rsplit(" ", 2)
+                       num_stmts = int(num_stmts)
+                       count = int(count)
+                   except ValueError:
+                       continue
+                   total += num_stmts
+                   if count > 0:
+                       covered += num_stmts
+
           report = {
               "repo":          repo,
               "language":      "go",
@@ -63,10 +84,10 @@ jobs:
               "branch":        os.environ.get("GITHUB_REF_NAME", "main"),
               "run_url":       f"https://github.com/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
               "line_rate":     float("${PCT}"),
-              "lines_covered": 0,
-              "lines_total":   0,
+              "lines_covered": covered,
+              "lines_total":   total,
           }
-          with open("coverage-report.json", "w") as f:
+          with open("coverage-report.json", "w", encoding="utf-8") as f:
             json.dump(report, f, indent=2)
           EOF
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ copywrite
 
 # Ignore local configs
 .env
+
+# Go test coverage profiles
+coverage.out

--- a/coverage-report.json
+++ b/coverage-report.json
@@ -1,0 +1,11 @@
+{
+  "repo": "copywrite",
+  "language": "go",
+  "date": "2026-06-24",
+  "commit": "",
+  "branch": "main",
+  "run_url": "",
+  "line_rate": 88.77,
+  "lines_covered": 332,
+  "lines_total": 374
+}

--- a/coverage-report.json
+++ b/coverage-report.json
@@ -1,11 +1,11 @@
 {
-  "repo": "copywrite",
+  "repo": "hashicorp/copywrite",
   "language": "go",
-  "date": "2026-06-24",
-  "commit": "",
-  "branch": "main",
-  "run_url": "",
-  "line_rate": 88.77,
-  "lines_covered": 332,
-  "lines_total": 374
+  "date": "2026-07-01",
+  "commit": "2b6d046",
+  "branch": "feature/add_coverage_file",
+  "run_url": "https://github.com/hashicorp/copywrite/actions/runs/28509524302",
+  "line_rate": 81.8,
+  "lines_covered": 0,
+  "lines_total": 0
 }

--- a/coverage-report.json
+++ b/coverage-report.json
@@ -2,10 +2,10 @@
   "repo": "hashicorp/copywrite",
   "language": "go",
   "date": "2026-07-01",
-  "commit": "2b6d046",
+  "commit": "8f0d577",
   "branch": "feature/add_coverage_file",
-  "run_url": "https://github.com/hashicorp/copywrite/actions/runs/28509524302",
+  "run_url": "https://github.com/hashicorp/copywrite/actions/runs/28511185693",
   "line_rate": 81.8,
-  "lines_covered": 0,
-  "lines_total": 0
+  "lines_covered": 1017,
+  "lines_total": 1414
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
- Add Coverage file(`coverage-report.json`) which contains data to display coverage metrics on dashboard.
- Add steps in CI workflow to compute the metrics needed in `coverage-report.json` and commit the file in the main branch on each push.

### :link: External Links

<!-- JIRA Issues, RFC, etc. -->
N/A

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?

### :thinking: Can be merged upon approval?

:white_check_mark:
<!-- if NO user :x: instead -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
